### PR TITLE
Upgrade to kresus 0.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@
 [![Integration level](https://dash.yunohost.org/integration/kresus.svg)](https://dash.yunohost.org/appci/app/kresus)
 [![Install Kresus with YunoHost](https://install-app.yunohost.org/install-with-yunohost.png)](https://install-app.yunohost.org/?app=kresus)
 
-> *This package allows you to install Kresus quickly and simply on a YunoHost server.  
+> *This package allows you to install Kresus quickly and simply on a YunoHost server.
 If you don't have YunoHost, please see [here](https://yunohost.org/#/install) to know how to install and enjoy it.*
 
 ## Overview
 
 Kresus is an open-source libre self-hosted personal finance manager. It allows you to safely track your banking history, check your overall balance and know exactly how you are spending money using categories!
 
-**Shipped version:** 0.15.2
+**Shipped version:** 0.16.0
 
 ## Screenshots
 
-![](https://kresus.org/images/pages/view-all-accounts.png)
+![Kresus reports view](https://kresus.org/images/pages/view-all-accounts.png?20200420)
 
 ## Demo
 
@@ -33,6 +33,8 @@ Kresus is an open-source libre self-hosted personal finance manager. It allows y
 * x86-64b - [![Build Status](https://ci-apps.yunohost.org/ci/logs/kresus%20%28Apps%29.svg)](https://ci-apps.yunohost.org/ci/apps/kresus/)
 * ARMv8-A - [![Build Status](https://ci-apps-arm.yunohost.org/ci/logs/kresus%20%28Apps%29.svg)](https://ci-apps-arm.yunohost.org/ci/apps/kresus/)
 * Jessie x86-64b - [![Build Status](https://ci-stretch.nohost.me/ci/logs/kresus%20%28Apps%29.svg)](https://ci-stretch.nohost.me/ci/apps/kresus/)
+
+32 bits architectures are not supported because nodejs does not provide builds for 32 bits anymore.
 
 ## Limitations
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://framagit.org/kresusapp/kresus/-/archive/0.15.2/kresus-0.15.2.tar.bz2
-SOURCE_SUM=420ed94313e3343f47d84095bd9adade166cc1e5d83f211d39cb2dd254bb63a6
+SOURCE_URL=https://framagit.org/kresusapp/kresus/-/archive/0.16.0/kresus-0.16.0.tar.bz2
+SOURCE_SUM=cf1757f317f1cc3cb659af0a76ed5ff2e0b00b9af19e7e30bec6518466ab6e97
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.bz2
 SOURCE_IN_SUBDIR=true

--- a/conf/config.ini
+++ b/conf/config.ini
@@ -49,6 +49,26 @@ python_exec=__FINALPATH__/venv/bin/python
 ; salt=gj4J89fkjf4h29aDi0f{}fu4389sejk`9osk`
 salt=__SALT__
 
+; Set this to true if you want to use this instance only in demo
+; mode, and to never allow users to link their personal accounts.
+;
+; WARNING! Switching this on and off may trigger data loss. Note that it
+; is still possible to try Kresus in demo mode, even if this is not set
+; to true. Setting this to true will *force* demo mode, and prevent users
+; from leaving this mode.
+; Can be removed; defaults to "false".
+; Overriden by the KRESUS_FORCE_DEMO_MODE environment variable, if it's set.
+; Example:
+; force_demo_mode=true
+force_demo_mode=
+
+; If set to a string, will enable HTTP Basic Auth, by splitting the
+; string on a colon, i.e. "<username>:<passwd>"
+; Overriden by the KRESUS_AUTH environment variable, if it's set.
+; Example:
+; auth=foo:bar
+auth=
+
 [weboob]
 ; The directory in which Weboob core is stored.
 ; Can be removed; defaults to "", indicating that weboob is already in the
@@ -125,6 +145,18 @@ force_tls=false
 ; variable, if it's set.
 reject_unauthorized_tls=true
 
+[notifications]
+
+; The baseurl from which apprise-api will be called for
+; notifications to be sent.
+; See https://github.com/caronc/apprise-api#installation for
+; installation
+; Overriden by the KRESUS_APPRISE_API_BASE_URL environment variable, if it's set.
+; Example:
+; appriseApiBaseUrl=http://localhost:8000/
+appriseApiBaseUrl=
+
+
 [logs]
 ; The path to the log file to use.
 ; Can be removed; defaults to kresus.log in kresus' datadir.
@@ -132,3 +164,66 @@ reject_unauthorized_tls=true
 ; Logs will still be written to stdout.
 log_file=
 
+[db]
+
+; Database type supported by Kresus, to choose among:
+; - postgres
+; - sqlite
+;
+; It must be set by the user. PostgreSQL is recommended and strongly supported; your experience with other databases might vary.
+;
+; Note using sqlite is *strongly discouraged* because it can't properly handle certain kinds of database migrations. It is only intended for development purposes.
+; Overriden by the KRESUS_DB_TYPE environment variable, if it's set.
+; Example:
+; type=sqlite
+type=postgres
+
+; Logging level for the SQL queries. Possible values are:
+;
+; - all: will log every SQL query, including queries causing errors.
+; - error (default value): will only log SQL queries resulting in errors. This is useful for debugging purposes.
+; - none: nothing will be logged.
+; Can be removed; defaults to "error".
+; Overriden by the KRESUS_DB_LOG environment variable, if it's set.
+; Example:
+; log=error
+log=
+
+; Path to the sqlite database file. Make sure that the user running
+; Kresus has the right permissions to write into this file. Required only for
+; sqlite.
+; Overriden by the KRESUS_DB_SQLITE_PATH environment variable, if it's set.
+; Example:
+; sqlite_path=/tmp/dev.sqlite
+sqlite_path=
+
+; Host address of the database server. Required for postgres.
+; Overriden by the KRESUS_DB_HOST environment variable, if it's set.
+; Example:
+; host=localhost
+host=localhost
+
+; Port of the database server. Required for postgres.
+; Overriden by the KRESUS_DB_PORT environment variable, if it's set.
+; Example:
+; port=5432 # postgres
+port=5432
+
+; Username to connect to the database server. Required for postgres.
+; Overriden by the KRESUS_DB_USERNAME environment variable, if it's set.
+; Example:
+; username=benjamin
+username=__DB_USER__
+
+; Password to connect to the database server. Required for postgres.
+; Overriden by the KRESUS_DB_PASSWORD environment variable, if it's set.
+; Example:
+; password=hunter2
+password=__DB_PASSWORD__
+
+; Database name to use. Required for postgres.
+; Can be removed; defaults to "kresus".
+; Overriden by the KRESUS_DB_NAME environment variable, if it's set.
+; Example:
+; name=kresus
+name=__DB_NAME__

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
     "requirements": {
         "yunohost": ">= 3.6.0"
     },
-    "version": "0.15.2~ynh4",
+    "version": "0.16.0~ynh1",
     "multi_instance": true,
     "services": [
         "nginx"
@@ -24,7 +24,7 @@
         "install" : [
             {
                 "name": "domain",
-		"type": "domain",
+                "type": "domain",
                 "ask": {
                     "en": "Choose a domain name for Kresus",
                     "fr": "Choisissez un nom de domaine pour Kresus"
@@ -33,7 +33,7 @@
             },
             {
                 "name": "path",
-		"type": "path",
+                "type": "path",
                 "ask": {
                     "en": "Choose a path for Kresus",
                     "fr": "Choisissez un chemin pour Kresus"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pkg_dependencies="dh-autoreconf	python3-pip python3-dev python3-lxml python3-pillow virtualenv"
+pkg_dependencies="dh-autoreconf	python3-pip python3-dev python3-lxml python3-pillow virtualenv postgresql"
 
 # Send an email to inform the administrator
 #
@@ -49,7 +49,7 @@ $app_message
 ---
 Automatic diagnosis data from YunoHost
 
-$(yunohost tools diagnosis | grep -B 100 "services:" | sed '/services:/d')"
+$(yunohost diagnosis show | grep -B 100 "services:" | sed '/services:/d')"
 
 	# Define binary to use for mail command
 	if [ -e /usr/bin/bsd-mailx ]

--- a/scripts/_ynh_detect_arch
+++ b/scripts/_ynh_detect_arch
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Check the architecture
+#
+# example: architecture=$(ynh_detect_arch)
+#
+# usage: ynh_detect_arch
+#
+# Requires YunoHost version 2.2.4 or higher.
+
+ynh_detect_arch(){
+	local architecture
+	if [ -n "$(uname -m | grep arm64)" ] || [ -n "$(uname -m | grep aarch64)" ]; then
+		architecture="arm64"
+	elif [ -n "$(uname -m | grep 64)" ]; then
+		architecture="x86-64"
+	elif [ -n "$(uname -m | grep 86)" ]; then
+		architecture="i386"
+	elif [ -n "$(uname -m | grep arm)" ]; then
+		architecture="arm"
+	else
+		architecture="unknown"
+	fi
+	echo $architecture
+}

--- a/scripts/backup
+++ b/scripts/backup
@@ -25,6 +25,8 @@ app=$YNH_APP_INSTANCE_NAME
 final_path=$(ynh_app_setting_get "$app" final_path)
 domain=$(ynh_app_setting_get "$app" domain)
 
+db_name="$app"
+
 #=================================================
 # STANDARD BACKUP STEPS
 #=================================================
@@ -38,6 +40,12 @@ ynh_backup "$final_path"
 #=================================================
 
 ynh_backup "/etc/nginx/conf.d/$domain.d/$app.conf"
+
+#=================================================
+# BACKUP THE POSTGRESQL DATABASE
+#=================================================
+
+ynh_psql_dump_db --database="$db_name" > ${YNH_CWD}/dump.sql
 
 #=================================================
 # SPECIFIC BACKUP

--- a/scripts/install
+++ b/scripts/install
@@ -7,6 +7,7 @@
 #=================================================
 
 source _common.sh
+source _ynh_detect_arch
 source /usr/share/yunohost/helpers
 
 #=================================================
@@ -30,6 +31,13 @@ app=$YNH_APP_INSTANCE_NAME
 # CHECK IF THE APP CAN BE INSTALLED WITH THESE ARGS
 #=================================================
 
+architecture=$(ynh_detect_arch)
+# Check machine architecture (in particular, we don't support ARM and 32bit machines)
+if [ $architecture == "i386" ]
+then
+	ynh_die --message="Sorry, because of nodejs framework, this app can't be installed on i386 (32 bits) machine."
+fi
+
 final_path="/var/www/$app"
 test ! -e "$final_path" || ynh_die "This path already contains a folder"
 
@@ -52,11 +60,17 @@ ynh_app_setting_set "$app" path "$path_url"
 # DEFAULT SETTINGS
 #=================================================
 
+db_name="$app"
+db_user="$app"
 port=$(ynh_find_port 9876)
 salt=$(ynh_string_random 40)
+db_pwd=$(ynh_string_random 40)
 
 ynh_app_setting_set "$app" port "$port"
 ynh_app_setting_set "$app" salt "$salt"
+ynh_print_OFF
+ynh_app_setting_set "$app" db_pwd "$db_pwd"
+ynh_print_ON
 
 #=================================================
 # STANDARD MODIFICATIONS
@@ -103,7 +117,7 @@ ynh_system_user_create "$app"
 #=================================================
 
 # install nodejs
-ynh_install_nodejs 10
+ynh_install_nodejs 12
 
 #=================================================
 # Install weboob with pip
@@ -131,17 +145,27 @@ ynh_use_nodejs
 )
 
 #=================================================
-# CONFIGURE HASTE
+# Setup Kresus postgresql database
+#=================================================
+
+ynh_psql_test_if_first_run
+ynh_psql_setup_db "$db_user" "$db_name" "$db_pwd"
+
+#=================================================
+# CONFIGURE KRESUS
 #=================================================
 
 cp ../conf/config.ini "$final_path/config.ini"
 
-ynh_replace_string "__PORT__"          "$port"       "$final_path/config.ini"
-ynh_replace_string "__PATH__"          "$path_url"   "$final_path/config.ini"
-ynh_replace_string "__FINALPATH__"     "$final_path" "$final_path/config.ini"
-ynh_replace_string "__SALT__"          "$salt"       "$final_path/config.ini"
-ynh_replace_string "__APP__"           "$app"        "$final_path/config.ini"
-ynh_replace_string "__DOMAIN__"        "$domain"     "$final_path/config.ini"
+ynh_replace_string "__PORT__"          "$port"               "$final_path/config.ini"
+ynh_replace_string "__PATH__"          "$path_url"           "$final_path/config.ini"
+ynh_replace_string "__FINALPATH__"     "$final_path"         "$final_path/config.ini"
+ynh_replace_string "__SALT__"          "$salt"               "$final_path/config.ini"
+ynh_replace_string "__APP__"           "$app"                "$final_path/config.ini"
+ynh_replace_string "__DOMAIN__"        "$domain"             "$final_path/config.ini"
+ynh_replace_string "__DB_NAME__"       "$db_user"            "$final_path/config.ini"
+ynh_replace_string "__DB_USER__"       "$db_name"            "$final_path/config.ini"
+ynh_replace_string "__DB_PASSWORD__"   "$db_pwd"             "$final_path/config.ini"
 
 
 # Calculate and store the config file checksum into the app settings
@@ -190,7 +214,7 @@ Path  : $path_url
 Config: $final_path/config.ini
 
 Please remember the default behavior of YunoHost when installing a new app is: everyone has access to the app.
-This may be an issue for Kresus as it is a personnal tool. Please remember to edit access rights in the YunoHost web administration panel or using command line interface.
+This may be an issue for Kresus as it is a personal tool. Please remember to edit access rights in the YunoHost web administration panel or using command line interface.
 
 Note about config.ini: this package will regenerate the config file on upgrade.
 If you changed it manually and upgrade Kresus, you'll find a backup in $final_path.

--- a/scripts/remove
+++ b/scripts/remove
@@ -18,6 +18,8 @@ app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get "$app" domain)
 port=$(ynh_app_setting_get "$app" port)
 final_path=$(ynh_app_setting_get "$app" final_path)
+db_name="$app"
+db_user="$app"
 
 #=================================================
 # STANDARD REMOVE
@@ -27,6 +29,13 @@ final_path=$(ynh_app_setting_get "$app" final_path)
 
 # Remove the dedicated systemd config
 ynh_remove_systemd_config
+
+#=================================================
+# REMOVE THE POSTGRESQL DATABASE
+#=================================================
+
+# Remove a database if it exists, along with the associated user
+ynh_psql_remove_db --db_user="$db_user" --db_name="$db_name"
 
 #=================================================
 # REMOVE DEPENDENCIES
@@ -41,7 +50,7 @@ ynh_remove_nodejs
 #=================================================
 
 # Remove the app directory securely
-ynh_secure_remove "$final_path"
+ynh_secure_remove --file="$final_path"
 
 #=================================================
 # REMOVE NGINX CONFIGURATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -7,6 +7,7 @@
 #=================================================
 
 source ../settings/scripts/_common.sh
+source ../settings/scripts/_ynh_detect_arch
 source /usr/share/yunohost/helpers
 
 #=================================================
@@ -22,13 +23,25 @@ ynh_abort_if_errors
 
 app=$YNH_APP_INSTANCE_NAME
 
+db_name="$app"
+db_user="$app"
+
 domain=$(ynh_app_setting_get "$app" domain)
 path_url=$(ynh_app_setting_get "$app" path)
 final_path=$(ynh_app_setting_get "$app" final_path)
+salt=$(ynh_app_setting_get "$app" salt)
+db_pwd=$(ynh_app_setting_get "$app" db_pwd)
 
 #=================================================
 # CHECK IF THE APP CAN BE RESTORED
 #=================================================
+
+architecture=$(ynh_detect_arch)
+# Check machine architecture (in particular, we don't support ARM and 32bit machines)
+if [ $architecture == "i386" ]
+then
+	ynh_die --message="Sorry, because of nodejs framework, this app can't be installed on i386 (32 bits) machine."
+fi
 
 ynh_webpath_available "$domain" "$path_url" \
 	|| ynh_die "Path not available: ${domain}${path_url}"
@@ -77,7 +90,17 @@ ynh_install_app_dependencies $pkg_dependencies
 # INSTALL NODEJS
 #=================================================
 
-ynh_install_nodejs 10
+ynh_install_nodejs 12
+
+#=================================================
+# RESTORE THE POSTGRESQL DATABASE
+#=================================================
+
+ynh_psql_test_if_first_run
+ynh_print_OFF
+ynh_psql_setup_db "$db_user" "$db_name" "$db_pwd"
+ynh_print_ON
+ynh_psql_execute_file_as_root --file="${YNH_CWD}/dump.sql" --database="$db_name"
 
 #=================================================
 # RESTORE SYSTEMD
@@ -87,7 +110,7 @@ ynh_restore_file "/etc/systemd/system/$app.service"
 systemctl enable "$app".service
 
 #=================================================
-# START HASTEBIN
+# START KRESUS
 #=================================================
 
 systemctl start "$app"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -18,11 +18,15 @@ ynh_abort_if_errors
 
 app=$YNH_APP_INSTANCE_NAME
 
+db_name="$app"
+db_user="$app"
+
 domain=$(ynh_app_setting_get "$app" domain)
 path_url=$(ynh_app_setting_get "$app" path)
 final_path=$(ynh_app_setting_get "$app" final_path)
 port=$(ynh_app_setting_get "$app" port)
 salt=$(ynh_app_setting_get "$app" salt)
+db_pwd=$(ynh_app_setting_get "$app" db_pwd)
 
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY
@@ -36,12 +40,22 @@ fi
 
 if [ -d "/home/ynh$app" ]; then
 	mv "/home/ynh$app/data" "$final_path/data"
-	ynh_secure_remove "/home/ynh$app"
+	ynh_secure_remove --file="/home/ynh$app"
 fi
 
 if [ -z "$salt" ]; then
 	salt=$(ynh_string_random 40)
 	ynh_app_setting_set "$app" salt "$salt"
+fi
+
+if [ -z "$db_pwd" ]; then
+	ynh_print_OFF
+	db_pwd=$(ynh_string_random 40)
+	ynh_app_setting_set "$app" db_pwd "$db_pwd"
+	ynh_print_ON
+
+	ynh_psql_test_if_first_run
+	ynh_psql_setup_db "$db_user" "$db_name" "$db_pwd"
 fi
 
 #=================================================
@@ -108,13 +122,13 @@ ynh_system_user_create "$app"
 #=================================================
 
 # install nodejs
-ynh_install_nodejs 10
+ynh_install_nodejs 12
 
 #=================================================
 # Install weboob with pip
 #=================================================
 
-ynh_secure_remove "${final_path}/venv"
+ynh_secure_remove --file="${final_path}/venv"
 virtualenv --python=python3 --system-site-packages "${final_path}/venv"
 (
 	set +o nounset
@@ -133,23 +147,31 @@ ynh_use_nodejs
 (
 	cd "$final_path"
 	chown -R "$app": "$final_path"
+
+	# In case of nodejs upgrade, remove the current node_modules to make sure there are no errors
+	# linked to modules compiled for the previous version.
+	ynh_secure_remove --file="$final_path/node_modules"
+
 	npm install --production --unsafe-perm
 )
 
 #=================================================
-# CONFIGURE HASTE
+# CONFIGURE KRESUS
 #=================================================
 
 ynh_backup_if_checksum_is_different "$final_path/config.ini"
 
 cp ../conf/config.ini "$final_path/config.ini"
 
-ynh_replace_string "__PORT__"          "$port"       "$final_path/config.ini"
-ynh_replace_string "__PATH__"          "$path_url"   "$final_path/config.ini"
-ynh_replace_string "__FINALPATH__"     "$final_path" "$final_path/config.ini"
-ynh_replace_string "__SALT__"          "$salt"       "$final_path/config.ini"
-ynh_replace_string "__APP__"           "$app"        "$final_path/config.ini"
-ynh_replace_string "__DOMAIN__"        "$domain"     "$final_path/config.ini"
+ynh_replace_string "__PORT__"          "$port"               "$final_path/config.ini"
+ynh_replace_string "__PATH__"          "$path_url"           "$final_path/config.ini"
+ynh_replace_string "__FINALPATH__"     "$final_path"         "$final_path/config.ini"
+ynh_replace_string "__SALT__"          "$salt"               "$final_path/config.ini"
+ynh_replace_string "__APP__"           "$app"                "$final_path/config.ini"
+ynh_replace_string "__DOMAIN__"        "$domain"             "$final_path/config.ini"
+ynh_replace_string "__DB_NAME__"       "$db_user"            "$final_path/config.ini"
+ynh_replace_string "__DB_USER__"       "$db_name"            "$final_path/config.ini"
+ynh_replace_string "__DB_PASSWORD__"   "$db_pwd"             "$final_path/config.ini"
 
 # Calculate and store the config file checksum into the app settings
 ynh_store_file_checksum "$final_path/config.ini"
@@ -206,7 +228,7 @@ Path  : $path_url
 Config: $final_path/config.ini
 
 Please remember the default behavior of YunoHost when installing a new app is: everyone has access to the app.
-This may be an issue for Kresus as it is a personnal tool. Please remember to edit access rights in the YunoHost web administration panel or using command line interface.
+This may be an issue for Kresus as it is a personal tool. Please remember to edit access rights in the YunoHost web administration panel or using command line interface.
 
 Note about config.ini: this package will regenerate the config file on upgrade.
 If you changed it manually and upgrade Kresus, you'll find a backup in $final_path.


### PR DESCRIPTION


Hi,

We published a new version of Kresus, the 0.16, that will now work with a postgresql database.
The remaining of the migration will be handled by Kresus for version 0.15 to 0.16 (for later versions an export and reimport will probably be needed).

Tests : 

- [x] Installation
- [x] Upgrade
- [x] Restoration
- [x] Deletion

