### PR TITLE
Remove diagnosis from email (fix #68)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,7 @@
     "requirements": {
         "yunohost": ">= 3.6.0"
     },
-    "version": "0.16.0~ynh2",
+    "version": "0.16.0~ynh3",
     "multi_instance": true,
     "services": [
         "nginx"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -44,12 +44,7 @@ ynh_send_readme_to_admin() {
 
 Specific information for the application $app.
 
-$app_message
-
----
-Automatic diagnosis data from YunoHost
-
-$(yunohost diagnosis show | grep -B 100 "services:" | sed '/services:/d')"
+$app_message"
 
 	# Define binary to use for mail command
 	if [ -e /usr/bin/bsd-mailx ]


### PR DESCRIPTION
Diagnosis will totally change in YunoHost 3.8 and the current command will not work as expected.
Discussed on IRC with YunoHost devs, this command might not be useful at all, and the admin will always be able to run the command itself.