### PR TITLE
Harden systemd-service

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -11,13 +11,33 @@ Environment="PATH=__YNH_NODE_LOAD_PATH__"
 Environment=NODE_ENV=production
 ExecStart=__FINALPATH__/bin/kresus.js --config __FINALPATH__/config.ini
 Restart=always
+AmbientCapabilities=
+CapabilityBoundingSet=
+LockPersonality=true
+#Not compatible with NodeJS
+#MemoryDenyWriteExecute=true
 NoNewPrivileges=true
 PrivateDevices=true
 PrivateTmp=true
+PrivateUsers=true
+ProtectClock=true
+ProtectControlGroups=true
 ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
 ProtectSystem=strict
-ProtectControlGroups=yes
-ProtectKernelModules=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+#SecureBits=noroot-locked
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+
 # to allow this systemd service to use sendmail.
 # references:
 #  https://bugs.archlinux.org/task/57721


### PR DESCRIPTION
## Problem

Current file is not up-to-date with latest hardening practices.

## Solution

Sync with current best practices.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
