### PR TITLE
Remove python3-pdfminer and fix missing pdfminer dependency instead

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="dh-autoreconf	python3-pip python3-dev python3-lxml python3-pillow virtualenv postgresql libffi-dev libopenjp2-7 python3-pdfminer"
+pkg_dependencies="dh-autoreconf	python3-pip python3-dev python3-lxml python3-pillow virtualenv postgresql libffi-dev libopenjp2-7"
 
 nodejs_version=14
 

--- a/scripts/install
+++ b/scripts/install
@@ -132,7 +132,7 @@ virtualenv --python=python3 --system-site-packages "${final_path}/venv"
 	set -o nounset
 
 	pip install --upgrade pip
-	pip install woob html2text simplejson BeautifulSoup4 PyExecJS pdfminer.six --ignore-installed
+	pip install woob html2text simplejson BeautifulSoup4 PyExecJS typing-extensions pdfminer.six --ignore-installed
 )
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -157,7 +157,7 @@ virtualenv --python=python3 --system-site-packages "${final_path}/venv"
 	set -o nounset
 
 	pip install --upgrade pip
-	pip install woob html2text simplejson BeautifulSoup4 PyExecJS pdfminer.six --ignore-installed
+	pip install woob html2text simplejson BeautifulSoup4 PyExecJS typing-extensions pdfminer.six --ignore-installed
 )
 
 #=================================================


### PR DESCRIPTION
## Problem

- pdfminer requires an extension for python < 3.8.

## Solution

- Add the dependency

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
