### PR TITLE
Fix dev dependencies still installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Kresus is an open-source libre self-hosted personal finance manager. It allows you to safely track your banking history, check your overall balance and know exactly how you are spending money using categories!
 
 
-**Shipped version:** 0.18.1~ynh8
+**Shipped version:** 0.18.1~ynh9
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -17,7 +17,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Kresus est un gestionnaire de finances personnelles gratuit et libre qui tourne sur votre serveur. Il récupère automatiquement et quotidiennement toutes vos nouvelles transactions bancaires et vous permet de les catégoriser, étudier via des graphiques, et établir un budget.
 
-**Version incluse :** 0.18.1~ynh8
+**Version incluse :** 0.18.1~ynh9
 
 ## Captures d'écran
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Personal finance manager",
         "fr": "Outil personnel de gestion de finances"
     },
-    "version": "0.18.1~ynh8",
+    "version": "0.18.1~ynh9",
     "url": "https://framagit.org/kresusapp/kresus",
     "upstream": {
         "license": "AGPL-3.0-only",

--- a/scripts/install
+++ b/scripts/install
@@ -153,7 +153,7 @@ ynh_script_progression --message="Installing app..." --weight=1
 ynh_use_nodejs
 (
 	cd "$final_path"
-	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn install
+	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn install --production
 	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn cache clean --all
 	ynh_secure_remove --file="$final_path/.cache"
 	ynh_secure_remove --file="$final_path/.yarn"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -189,7 +189,7 @@ ynh_use_nodejs
 	# linked to modules compiled for the previous version.
 	ynh_secure_remove --file="$final_path/node_modules"
 
-	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn install
+	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn install --production
 	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH yarn cache clean --all
 	ynh_secure_remove --file="$final_path/.cache"
 	ynh_secure_remove --file="$final_path/.yarn"


### PR DESCRIPTION
## Problem

- Dev dependencies are still installed whereas useless

## Solution

- Use `yarn install --production`

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
