### PR TITLE
Rustup minimal

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -134,7 +134,7 @@ ynh_exec_as $app virtualenv --python=python3 --system-site-packages "${final_pat
 	source "${final_path}/venv/bin/activate"
 	set -o nounset
 
-	ynh_exec_warn_less ynh_exec_as $app RUSTUP_HOME="$final_path"/.rustup CARGO_HOME="$final_path"/.cargo bash -c 'curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -q -y'
+	ynh_exec_warn_less ynh_exec_as $app RUSTUP_HOME="$final_path"/.rustup CARGO_HOME="$final_path"/.cargo bash -c 'curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -q -y --default-toolchain=stable --profile=minimal'
 	export PATH="$final_path/.cargo/bin:$PATH"
 	ynh_exec_warn_less ynh_exec_as $app env PATH=$PATH pip install --upgrade pip
 	ynh_exec_warn_less ynh_exec_as $app env PATH=$PATH pip install --upgrade setuptools

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -165,7 +165,7 @@ ynh_exec_as $app virtualenv --python=python3 --system-site-packages "${final_pat
 	source "${final_path}/venv/bin/activate"
 	set -o nounset
 
-	ynh_exec_warn_less ynh_exec_as $app RUSTUP_HOME="$final_path"/.rustup CARGO_HOME="$final_path"/.cargo bash -c 'curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -q -y'
+	ynh_exec_warn_less ynh_exec_as $app RUSTUP_HOME="$final_path"/.rustup CARGO_HOME="$final_path"/.cargo bash -c 'curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -q -y --default-toolchain=stable --profile=minimal'
 	export PATH="$final_path/.cargo/bin:$PATH"
 	ynh_exec_warn_less ynh_exec_as $app env PATH=$PATH pip install --upgrade pip
 	ynh_exec_warn_less ynh_exec_as $app env PATH=$PATH pip install --upgrade setuptools


### PR DESCRIPTION
## Problem

- Rustup auto-detection of armfh is incorrect and the installation fails on raspberry 4.

## Solution

- Use rustup minimal profile

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
