### PR TITLE
Don't check SMTP cert validity

### DIFF
--- a/conf/config.ini
+++ b/conf/config.ini
@@ -176,7 +176,7 @@ force_tls=false
 ; Overriden by the KRESUS_EMAIL_REJECT_UNAUTHORIZED_TLS environment variable, if it's set.
 ; Example:
 ; reject_unauthorized_tls=true
-reject_unauthorized_tls=true
+reject_unauthorized_tls=false
 
 [notifications]
 


### PR DESCRIPTION
## Problem

- Kresus cannot send e-mails. #176 

## Solution

- Disable SSL cert validation as the cert presented when connecting to `127.0.0.1` is issued to `maindomain.tld`.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
