### PR TITLE
[CI] Do not run locales commands (locale-gen/update-locale) on CI (fo…

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -61,8 +61,12 @@ yunohost service add $app --description="Personal finance manager" --log="/var/l
 #=================================================
 ynh_script_progression --message="Installing woob..." --weight=1
 
-locale-gen C.UTF-8
-update-locale C.UTF-8
+# The CI will fail on these, even though the locales package is installed.
+if ! [ ${PACKAGE_CHECK_EXEC:-0} -eq 1 ]; then
+	locale-gen C.UTF-8
+	update-locale C.UTF-8
+fi
+
 ynh_exec_as $app virtualenv --python=python3 --system-site-packages "${install_dir}/venv"
 (
 	set +o nounset

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -88,8 +88,12 @@ yunohost service add $app --description="Personal finance manager" --log="/var/l
 #=================================================
 ynh_script_progression --message="Installing woob..." --weight=1
 
-locale-gen C.UTF-8
-update-locale C.UTF-8
+# The CI will fail on these, even though the locales package is installed.
+if ! [ ${PACKAGE_CHECK_EXEC:-0} -eq 1 ]; then
+	locale-gen C.UTF-8
+	update-locale C.UTF-8
+fi
+
 ynh_secure_remove --file="${install_dir}/venv"
 ynh_exec_as $app virtualenv --python=python3 --system-site-packages "${install_dir}/venv"
 (


### PR DESCRIPTION
…llowing CI upgrade and commands failing)

## Problem

- Package is marked as broken whereas only an upgrade to the CI env was made, breaking everything: https://ci-apps.yunohost.org/ci/job/30290

## Solution

- Do not run locales commands on CI

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
