### PR TITLE
Fix python-jose dependency

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -62,7 +62,7 @@ ram.runtime = "50M"
     [resources.ports]
 
     [resources.apt]
-    packages = "locales, git, python3, python3-dev, python3-pip, python3-selenium, python3-josepy, libffi-dev, libxml2-dev, libxslt-dev, libyaml-dev, libtiff-dev, libjpeg-dev, libopenjp2-7-dev, zlib1g-dev, libfreetype6-dev, libwebp-dev, build-essential, gcc, g++, wget, unzip, mupdf-tools, libnss3-tools, python3-nss, virtualenv, postgresql"
+    packages = "locales, git, python3, python3-dev, python3-pip, python3-selenium, python3-jose, libffi-dev, libxml2-dev, libxslt-dev, libyaml-dev, libtiff-dev, libjpeg-dev, libopenjp2-7-dev, zlib1g-dev, libfreetype6-dev, libwebp-dev, build-essential, gcc, g++, wget, unzip, mupdf-tools, libnss3-tools, python3-nss, virtualenv, postgresql"
     extras.yarn.repo = "deb https://dl.yarnpkg.com/debian/ stable main"
     extras.yarn.key = "https://dl.yarnpkg.com/debian/pubkey.gpg"
     extras.yarn.packages = "yarn"


### PR DESCRIPTION
## Problem

- I get a missing `python-jose` error when I try to add an account (see #186)

## Solution

- I replaced `python3-josepy` package by `python3-jose`, which is the up to date one.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
