### PR TITLE
Remove nsss from dependencies (deprecated since woob 3.4)

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -64,7 +64,7 @@ ram.runtime = "50M"
     [resources.ports]
 
     [resources.apt]
-    packages = "locales, git, python3, python3-dev, python3-pip, python3-selenium, python3-jose, libffi-dev, libxml2-dev, libxslt-dev, libyaml-dev, libtiff-dev, libjpeg-dev, libopenjp2-7-dev, zlib1g-dev, libfreetype6-dev, libwebp-dev, build-essential, gcc, g++, wget, unzip, mupdf-tools, libnss3-tools, python3-nss, virtualenv, postgresql"
+    packages = "locales, git, python3, python3-dev, python3-pip, python3-selenium, python3-jose, libffi-dev, libxml2-dev, libxslt-dev, libyaml-dev, libtiff-dev, libjpeg-dev, libopenjp2-7-dev, zlib1g-dev, libfreetype6-dev, libwebp-dev, build-essential, gcc, g++, wget, unzip, mupdf-tools, virtualenv, postgresql"
     extras.yarn.repo = "deb https://dl.yarnpkg.com/debian/ stable main"
     extras.yarn.key = "https://dl.yarnpkg.com/debian/pubkey.gpg"
     extras.yarn.packages = "yarn"


### PR DESCRIPTION
## Problem

- NSS is not needed nor supported in Kresus new versions.

## Solution

- Remove NSS dependencies

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
